### PR TITLE
utils: create FXs to set and get localStorage for form elements

### DIFF
--- a/js/utils/storage.js
+++ b/js/utils/storage.js
@@ -1,0 +1,7 @@
+export function setLocalStorage(obj) {
+  localStorage.setItem('userSettings', JSON.stringify(obj));
+}
+
+export function getLocalStorage() {
+  return JSON.parse(localStorage.getItem('userSettings'));
+}


### PR DESCRIPTION
Created `setLocalStorage(obj)` and `getLocalStorage()` in `utils/`. Closes #1.