### PR TITLE
ui: create functions to populate both forms

### DIFF
--- a/js/ui/setupForms.js
+++ b/js/ui/setupForms.js
@@ -1,0 +1,25 @@
+import { TUNINGS } from "../data/constants.js";
+import { getLocalStorage } from "../utils/storage.js";
+
+const tuningsSelect = document.getElementById('tunings-select');
+const stringsDiv = document.getElementById('strings');
+
+// Load instruments tunings into the DOM (Settings Form)
+export function loadTunings(index) {
+  const instrumentTunings = TUNINGS[index];
+
+  let i = 0;
+
+  for (const tuning in instrumentTunings) {
+    const option = document.createElement('option');
+    option.setAttribute('value', i);
+    i++;
+
+    // Stringify the tunings arrays then append to the DOM
+    const tuningString = instrumentTunings[tuning].join('-');
+    const optionText = document.createTextNode(`${tuning}: ${tuningString}`);
+
+    option.append(optionText);
+    tuningsSelect.append(option);
+  }
+}

--- a/js/ui/setupForms.js
+++ b/js/ui/setupForms.js
@@ -31,3 +31,30 @@ export function loadStrings(index) {
   const currentTuning = Object.values(instrumentTunings)[index]
   createStrings(currentTuning);
 }
+
+// Create number inputs and labels then append to the DOM (Frets Form)
+function createStrings(tuning) {
+  tuning.forEach((string, i) => {
+
+    // label and input container
+    const div = document.createElement('div');
+    div.setAttribute('class', 'string-group');
+
+    const label = document.createElement('label');
+    label.setAttribute('for', `str-${i + 1}`);
+    label.setAttribute('class', 'form-label');
+    label.append(document.createTextNode(string))
+
+    const input = document.createElement('input');
+    input.setAttribute('type', 'number');
+    input.setAttribute('class', 'form-control note');
+    input.setAttribute('id', `str-${i + 1}`);
+    input.setAttribute('min', '0');
+    input.setAttribute('step', '1');
+    input.setAttribute('max', '18');
+
+    div.append(label);
+    div.append(input);
+    stringsDiv.append(div)
+  })
+}

--- a/js/ui/setupForms.js
+++ b/js/ui/setupForms.js
@@ -23,3 +23,11 @@ export function loadTunings(index) {
     tuningsSelect.append(option);
   }
 }
+
+// Load number inputs and labels into the DOM on instrument select or tunings select (Frets Form)
+export function loadStrings(index) {
+  const savedSettings = getLocalStorage();
+  const instrumentTunings = TUNINGS[savedSettings.instrument];
+  const currentTuning = Object.values(instrumentTunings)[index]
+  createStrings(currentTuning);
+}


### PR DESCRIPTION
In ui/setupForms I created:

1. loadTunings to load the tunings into the settings form based on the instrument selected
2. loadStrings to grab the tuning in local storage and pass it to createStrings
3. createStrings: takes the tuning and creates a label and number input for each note then appends those into the DOM

Closes #5.